### PR TITLE
feat(swatch): indicate the selected color

### DIFF
--- a/src/components/sketch/Sketch.tsx
+++ b/src/components/sketch/Sketch.tsx
@@ -154,7 +154,11 @@ export function Sketch({
         onChange={changeColor}
         disableAlpha={disableAlpha}
       />
-      <SketchPresetColors colors={presetColors} onClick={changeColor} />
+      <SketchPresetColors
+        colors={presetColors}
+        currentColor={colors}
+        onClick={changeColor}
+      />
     </div>
   );
 }

--- a/src/components/sketch/SketchPresetColors.tsx
+++ b/src/components/sketch/SketchPresetColors.tsx
@@ -1,14 +1,16 @@
 import React from "react";
-import { ChangeColor } from "../../types/colors";
+import { ChangeColor, ColorResult } from "../../types/colors";
 import { Swatch } from "../common";
 
 type Props = {
   colors: (string | { color: string; title?: string })[];
+  currentColor: ColorResult;
   onClick?: (newColor: ChangeColor, event: React.MouseEvent) => void;
 };
 
 export default function SketchPresetColors({
   colors,
+  currentColor,
   onClick = () => {},
 }: Props) {
   const noPresets = !colors || !colors.length;
@@ -30,6 +32,9 @@ export default function SketchPresetColors({
     swatch: {
       borderRadius: "3px",
       boxShadow: "inset 0 0 0 1px rgba(0,0,0,.15)",
+      fontSize: "14px",
+      textAlign: "center",
+      fontWeight: "bold",
     },
   };
 
@@ -51,16 +56,32 @@ export default function SketchPresetColors({
             ? { color: colorObjOrString }
             : colorObjOrString;
         const key = `${c.color}${("title" in c ? c.title : "") || ""}`;
+
+        const isCurrent = currentColor.hex.toUpperCase() === c.color;
+
+        const textColor =
+          currentColor.rgb.r * 0.299 +
+            currentColor.rgb.g * 0.587 +
+            currentColor.rgb.b * 0.114 >
+          186
+            ? "#000000"
+            : "#ffffff";
+
         return (
           <div key={key} style={styles.swatchWrap}>
             <Swatch
               {...c}
-              style={styles.swatch}
+              style={{
+                ...styles.swatch,
+                color: textColor,
+              }}
               onClick={handleClick}
               focusStyle={{
                 boxShadow: `inset 0 0 0 1px rgba(0,0,0,.15), 0 0 4px ${c.color}`,
               }}
-            />
+            >
+              {isCurrent && <>&#x2713;</>}
+            </Swatch>
           </div>
         );
       })}

--- a/src/components/sketch/spec.js
+++ b/src/components/sketch/spec.js
@@ -61,7 +61,12 @@ test("SketchFields renders correctly", () => {
 
 test("SketchPresetColors renders correctly", () => {
   const tree = renderer
-    .create(<SketchPresetColors colors={["#fff", "#999", "#000"]} />)
+    .create(
+      <SketchPresetColors
+        colors={["#fff", "#999", "#000"]}
+        currentColor={color.red}
+      />
+    )
     .toJSON();
   expect(tree).toMatchSnapshot();
 });
@@ -81,6 +86,8 @@ test("SketchPresetColors with custom titles renders correctly", () => {
     },
     "#f00",
   ];
-  const tree = renderer.create(<SketchPresetColors colors={colors} />).toJSON();
+  const tree = renderer
+    .create(<SketchPresetColors colors={colors} currentColor={color.red} />)
+    .toJSON();
   expect(tree).toMatchSnapshot();
 });


### PR DESCRIPTION
This is a small change to show which color in the swatches matches the current color, if any do.

It is choosing either a black or white tick depending on the color it will be drawn over

![image](https://user-images.githubusercontent.com/1327476/202916135-32de2c7b-0ceb-4fa0-b25d-c4655796df13.png)


The tests currently look pretty broken, so I haven't checked that these changes don't cause any breakages there.

